### PR TITLE
Add maturin, kmedoids to osx_arm64.txt

### DIFF
--- a/recipe/migrations/osx_arm64.txt
+++ b/recipe/migrations/osx_arm64.txt
@@ -602,6 +602,8 @@ gst-plugins-bad
 pycbc
 python-pushover
 rustpython
+maturin
+kmedoids
 binaryen
 gfal2-util
 randomgen


### PR DESCRIPTION
OSX ARM64 support has been requested at https://github.com/kno10/python-kmedoids/issues/25 kmedoids needs maturin for building the Rust parts. This worked without issues via cross-compilation in github actions for pypy, so I do not expect major issues. (I noticed that polars is on the list, which also has build dependencies on maturin, so probably it is even enough to have maturin on the host system - I would still add it to make it easier for Apple users to do local development).